### PR TITLE
allow fields with @requires directive to have their own inputs

### DIFF
--- a/graphene_federation/service.py
+++ b/graphene_federation/service.py
@@ -18,7 +18,7 @@ def _mark_field(
             # todo write tests on regexp
             schema_field_name = to_camel_case(field_name) if auto_camelcase else field_name
             pattern = re.compile(
-                r"(type\s%s\s[^\{]*\{.*\s%s[\s]*(\([^\)]*\))?:[\s]*[^\s]+)(\s)" % (
+                r"(type\s%s\s[^\{]*\{[\S\s]*?\s%s[\s]*(\([^\)]*\))?:[\s]*[^\s]+)(\s)" % (
                     entity_name, schema_field_name))
             schema = pattern.sub(
                 rf'\g<1> {decorator_resolver(getattr(field, mark_attr_name))} ', schema)

--- a/graphene_federation/service.py
+++ b/graphene_federation/service.py
@@ -18,7 +18,7 @@ def _mark_field(
             # todo write tests on regexp
             schema_field_name = to_camel_case(field_name) if auto_camelcase else field_name
             pattern = re.compile(
-                r"(type\s%s\s[^\{]*\{[\S\s]*?\s%s[\s]*(\([^\)]*\))?:[\s]*[^\s]+)(\s)" % (
+                r"(type\s%s\s[^\{]*\{[\S\s]*?\s%s[\s]*(\([^\)]*\)\s*)?:[\s]*[^\s]+)(\s)" % (
                     entity_name, schema_field_name))
             schema = pattern.sub(
                 rf'\g<1> {decorator_resolver(getattr(field, mark_attr_name))} ', schema)

--- a/graphene_federation/service.py
+++ b/graphene_federation/service.py
@@ -18,7 +18,7 @@ def _mark_field(
             # todo write tests on regexp
             schema_field_name = to_camel_case(field_name) if auto_camelcase else field_name
             pattern = re.compile(
-                r"(type\s%s\s[^\{]*\{[^\}]*\s%s[\s]*:[\s]*[^\s]+)(\s)" % (
+                r"(type\s%s\s[^\{]*\{.*\s%s[\s]*(\([^\)]*\))?:[\s]*[^\s]+)(\s)" % (
                     entity_name, schema_field_name))
             schema = pattern.sub(
                 rf'\g<1> {decorator_resolver(getattr(field, mark_attr_name))} ', schema)

--- a/integration_tests/service_c/src/schema.py
+++ b/integration_tests/service_c/src/schema.py
@@ -1,4 +1,4 @@
-from graphene import ObjectType, String, Int, List, NonNull, Field
+from graphene import ObjectType, String, Int, List, NonNull, Field, Boolean
 from graphene_federation import build_schema, extend, external, requires, key, provides
 
 
@@ -8,12 +8,17 @@ class User(ObjectType):
     primary_email = external(String())
     uppercase_email = requires(String(), fields='primaryEmail')
     age = external(Int())
+    email_domain = requires(String(required=True, upper_case=Boolean()), fields='primaryEmail')
 
     def resolve_uppercase_email(self, info):
         return self.primary_email.upper() if self.primary_email else self.primary_email
 
     def resolve_age(self, info):
         return 18
+
+    def resolve_email_domain(self, info, **kwargs):
+        domain = self.primary_email.split('@')[-1] if self.primary_email else ''
+        return domain.upper() if kwargs['upper_case'] else domain
 
 
 @key(fields='id')

--- a/integration_tests/tests/tests/test_main.py
+++ b/integration_tests/tests/tests/test_main.py
@@ -129,6 +129,7 @@ def test_requires():
                     text
                     author {
                         uppercaseEmail
+                        emailDomain(upperCase:true)
                     }
                 }
             }
@@ -144,7 +145,7 @@ def test_requires():
     articles = data['articles']
 
     assert articles == [
-        {'id': 1, 'text': 'some text', 'author': {'uppercaseEmail': 'NAME_5@GMAIL.COM'}}]
+        {'id': 1, 'text': 'some text', 'author': {'uppercaseEmail': 'NAME_5@GMAIL.COM', 'emailDomain': 'GMAIL.COM'}}]
 
 
 def test_provides():


### PR DESCRIPTION
If we have something as simple as:

```gql
extend type Acme @key(fields: "id") {
  id: ID! @external
  age: Int @external
  foo: String @requires(fields: "age")
}
```

everything works as expected, but if we gonna need to have some inputs on our `foo` field then nothing will work, e.g.:

```gql
extend type Acme @key(fields: "id") {
  id: ID! @external
  age: Int @external
  foo(someInput: String): String @requires(fields: "age")
}
```

will produce sdl where `foo` field wont have `@requires` directive

thats why we gonna need this `(\([^\)]*\)\s*)?` addition to regexp to allow optional arguments

change of `[\S\s]*?` is needed because previous change will start changing schema for each run and regexp wont catch next fields

Integration test is added to prevent regression in future