### PR TITLE
Allow federated field with arguments - pattern matching

### DIFF
--- a/graphene_federation/service.py
+++ b/graphene_federation/service.py
@@ -18,7 +18,7 @@ def _mark_field(
             # todo write tests on regexp
             schema_field_name = to_camel_case(field_name) if auto_camelcase else field_name
             pattern = re.compile(
-                r"(type\s%s\s[^\{]*\{[^\}]*\s%s[\s]*:[\s]*[^\s]+)(\s)" % (
+                r"(type\s%s\s[^\{]*\{[^\}]*\s%s[\s]*(\([^\)]*\))?[\s]*:[\s]*[^\s]+)(\s)" % (
                     entity_name, schema_field_name))
             schema = pattern.sub(
                 rf'\g<1> {decorator_resolver(getattr(field, mark_attr_name))} ', schema)


### PR DESCRIPTION
When extending a federated type it is possible to have arguments when resolving the field. As is `graphene-federation` doesn't allow this as it can't pattern match it.