### PR TITLE
preserve original formatting generated by schema_printer

### DIFF
--- a/graphene_federation/service.py
+++ b/graphene_federation/service.py
@@ -47,7 +47,6 @@ def _mark_provides(entity_name, entity, schema, auto_camelcase):
 
 def get_sdl(schema, custom_entities):
     string_schema = str(schema)
-    string_schema = string_schema.replace("\n", " ")
 
     regex = r"schema \{(\w|\!|\s|\:)*\}"
     pattern = re.compile(regex)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 def read(*rnames):
   return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
-version = '0.1.0'
+version = '0.2.0'
 
 setup(
   name = 'graphene-federation',


### PR DESCRIPTION
current behaviour of get_sdl is to strip all line breaks, which then forces us to recreate schema with weird regex hooks.
this should fix this behaviour.