### PR TITLE
Setup unit tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ test:
 	cd integration_tests && docker-compose down && docker-compose run --rm tests
 
 unittest:
-    pytest tests/
+	pytest tests/

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ build:
 
 test:
 	cd integration_tests && docker-compose down && docker-compose run --rm tests
+
+unittest:
+    pytest tests/

--- a/tests/test_extend.py
+++ b/tests/test_extend.py
@@ -1,0 +1,14 @@
+from graphene import Int, String
+
+from graphene_federation.extend import external, requires
+
+
+def test_external():
+    field = external(Int(required=True))
+    assert field._external is True
+
+
+def test_requires():
+    fields = 'primaryEmail'
+    field = requires(String(), fields=fields)
+    assert field._requires == fields


### PR DESCRIPTION
This PR does the following:
- Setup files structure for unit tests
- Add a new command called `unittest` to Makefile
- Implement two simple tests: `test_external` and `test_requires`